### PR TITLE
Updated ArduinoJson to ~7.1.0

### DIFF
--- a/library.json
+++ b/library.json
@@ -19,7 +19,7 @@
 	"license": "Apache-2.0",
 	"homepage": "https://reticulum.network/",
 	"dependencies": {
-		"ArduinoJson": "~6.21.3"
+		"ArduinoJson": "~7.1.0"
 	},
 	"frameworks": "*",
 	"platforms": "*",

--- a/platformio.ini
+++ b/platformio.ini
@@ -25,7 +25,7 @@ build_flags =
 	-DRNS_USE_FS
 	-DRNS_PERSIST_PATHS
 lib_deps = 
-	ArduinoJson@^6.21.3
+	ArduinoJson@^7.1.0
 	https://github.com/attermann/Crypto.git
 
 [env:native]


### PR DESCRIPTION
Updated ArduinoJson to ~7.1.0

This is needed for msgpack binary string support (which is used by LXMF for things like display names).
There were some breaking API changes in some of the obscure corners of ArduinoJson, but it didn't appear to affect anything in MicroReticulum. 